### PR TITLE
Page header

### DIFF
--- a/frontend/memecataloger/e2e-tests/app.spec.ts
+++ b/frontend/memecataloger/e2e-tests/app.spec.ts
@@ -6,6 +6,12 @@ test('has title', async ({ page }) => {
   await expect(page).toHaveTitle(/MemeCataloger/);
 });
 
+test('page header is visible', async ({page}) => {
+  await page.goto('http://127.0.0.1:3000');
+  await expect(page.getByText('MemeCataloger')).toBeVisible();
+  await expect(page.getByText('MemeCataloger')).toHaveCount(1);
+});
+
 test('test thumbnails visible', async ({ page }) => {
   await page.goto('http://127.0.0.1:3000');
   await expect(page.getByRole('link')).toHaveCount(17);

--- a/frontend/memecataloger/src/app/header.module.css
+++ b/frontend/memecataloger/src/app/header.module.css
@@ -1,0 +1,21 @@
+.headerOuterDiv{
+  position: relative;
+}
+
+.headerInnerDiv {
+  position: fixed;
+  background-color: blue;
+  width: 110vw;
+  height: 10vh;
+  margin: 0;
+  overflow: scroll;
+  justify-content: center;
+  align-content: center;
+  z-index: 1;
+}
+
+.headerTitle {
+  position: relative;
+  font-size: medium;
+  margin: 0 auto 0 2vw;
+}

--- a/frontend/memecataloger/src/app/header.tsx
+++ b/frontend/memecataloger/src/app/header.tsx
@@ -1,0 +1,13 @@
+import styles from "./header.module.css"
+
+
+export default function Header() {
+
+  return(
+    <div className={styles.headerOuterDiv}>
+      <div className={styles.headerInnerDiv}>
+        <h2 className={styles.headerTitle}>MemeCataloger</h2>
+      </div>
+    </div>
+  );
+};

--- a/frontend/memecataloger/src/app/image/[imageId]/page.css
+++ b/frontend/memecataloger/src/app/image/[imageId]/page.css
@@ -1,6 +1,6 @@
 .image-display {
   display: block;
-  margin: auto;
+  margin: 12vh auto auto auto;
   /* Thanks to StackOverflow user setec!
    * https://stackoverflow.com/questions/12991351/how-to-force-image-resize-and-keep-aspect-ratio
    */

--- a/frontend/memecataloger/src/app/layout.tsx
+++ b/frontend/memecataloger/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
-import "./globals.css";
+import "./globals.css"
+
+import Header from "./header";
 
 
 export const metadata: Metadata = {
@@ -18,8 +20,9 @@ export default function RootLayout({
         <link rel="icon" href="/favicon.jpg" />
       </head>
       <body>
-        {children}
+          <Header />
+          {children}
       </body>
     </html>
   );
-}
+};

--- a/frontend/memecataloger/src/app/page.tsx
+++ b/frontend/memecataloger/src/app/page.tsx
@@ -8,7 +8,6 @@ export default function Home() {
     <div className={styles.page}>
       <main className={styles.main}>
         <ImageList/>
-        {/* <Thumbnail src="/20201109_113624.jpg" id={1}/> */}
       </main>
     </div>
   );

--- a/frontend/memecataloger/src/app/thumbnail.css
+++ b/frontend/memecataloger/src/app/thumbnail.css
@@ -11,5 +11,6 @@
   aspect-ratio: 1/1;
   width: 98%;
   overflow: hidden;
-  margin: .5vh
+  margin: .5vh;
+  z-index: 0;
 }

--- a/frontend/memecataloger/src/component-tests/header.test.js
+++ b/frontend/memecataloger/src/component-tests/header.test.js
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+
+import Header from "../app/header";
+
+
+describe("Page-Header", () => {
+  
+  test("header title is visible", () => {
+    render(
+        <Header />
+    );
+
+    expect(screen.getByText("MemeCataloger")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #30 on merge; adds a top nav bar/page header to the page.  Note that items are kept from slipping under the page header by a 10vh tall relative-position div, and it seems that components at the top of the page will need 10vh added to the desired margin to keep from sinking under the page header.  (That might be issue-worthy in the future, but it works as well as it did on the old version of this project, so we're calling it good enough for now.)