### PR TITLE
fix(docker): Updated image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # See build steps below
-FROM codyswanner/memecataloger-nextjs:frontend-25.09.1
+FROM codyswanner/memecataloger-nextjs:frontend-25.10.1
 
 # Run server and ensure container stays open
 CMD ["bash", "-c", "npm ci; npm run dev; tail -f /dev/null"]

--- a/frontend/Dockerfile-baseline
+++ b/frontend/Dockerfile-baseline
@@ -4,7 +4,7 @@
 ###############################################################################
 
 
-FROM node:lts-slim
+FROM node:current-slim
 
 RUN apt-get update \
 	&& apt-get upgrade -y \
@@ -29,4 +29,4 @@ RUN npx playwright install --with-deps firefox
 RUN npm install
 
 # USER front-runner
-CMD ["bash", "-c", "npm run dev; tail -f /dev/null"]
+CMD ["bash", "-c", "npm install; npm run dev; tail -f /dev/null"]


### PR DESCRIPTION
New Node/npm version rollout two weeks ago seems to be causing issues with starting the frontend container.  Switched to `node:current-lts` to resolve this issue, added a step to the container build to try to help mitigate this in the future, and incremented the version number of the image to be pulled from Docker Hub.